### PR TITLE
Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.6-alpine3.6
+
+EXPOSE 8000
+VOLUME ["/downloads"]
+
+COPY . /app
+WORKDIR /app
+
+# Temp (alpine mirror having issues)
+RUN echo http://dl-2.alpinelinux.org/alpine/v3.6/main > /etc/apk/repositories; \
+    echo http://dl-2.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories
+
+RUN apk --update --no-cache add ffmpeg wget nodejs nodejs-npm
+RUN pip install scdl youtube-dl
+RUN pip install -r requirements.txt
+RUN npm install webpack -g
+RUN webpack
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,6 @@
+app:
+  build: .
+  ports:
+    - '8000:8000'
+  volumes:
+    - '/tmp:/downloads'


### PR DESCRIPTION
Image build fine but having problems actually getting the app to work. Seems there's some missing js dependencies or something.

Had to have webpack run since none of the bundles were in the repo (thats fine, I like it that way anyways).

Getting this error:

```
bootstrap.min.js:6 Uncaught Error: Bootstrap dropdown require Popper.js (https://popper.js.org)
    at bootstrap.min.js:6
    at bootstrap.min.js:6
    at bootstrap.min.js:6
(anonymous) @ bootstrap.min.js:6
(anonymous) @ bootstrap.min.js:6
(anonymous) @ bootstrap.min.js:6
main-4f877995211a07a39522.js:27616 Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
printWarning @ main-4f877995211a07a39522.js:27616
lowPriorityWarning @ main-4f877995211a07a39522.js:27635
get @ main-4f877995211a07a39522.js:5948
exports.__esModule @ main-4f877995211a07a39522.js:90552
__webpack_require__ @ main-4f877995211a07a39522.js:20
Object.defineProperty.value @ main-4f877995211a07a39522.js:11365
__webpack_require__ @ main-4f877995211a07a39522.js:20
Object.defineProperty.value @ main-4f877995211a07a39522.js:42699
__webpack_require__ @ main-4f877995211a07a39522.js:20
exports.__esModule @ main-4f877995211a07a39522.js:6402
__webpack_require__ @ main-4f877995211a07a39522.js:20
Object.defineProperty.value @ main-4f877995211a07a39522.js:41396
__webpack_require__ @ main-4f877995211a07a39522.js:20
Object.defineProperty.value @ main-4f877995211a07a39522.js:41530
__webpack_require__ @ main-4f877995211a07a39522.js:20
Object.defineProperty.value @ main-4f877995211a07a39522.js:41464
__webpack_require__ @ main-4f877995211a07a39522.js:20
Object.defineProperty.value @ main-4f877995211a07a39522.js:42029
__webpack_require__ @ main-4f877995211a07a39522.js:20
Object.defineProperty.value @ main-4f877995211a07a39522.js:42236
__webpack_require__ @ main-4f877995211a07a39522.js:20
Object.defineProperty.value @ main-4f877995211a07a39522.js:40518
__webpack_require__ @ main-4f877995211a07a39522.js:20
Object.defineProperty.value @ main-4f877995211a07a39522.js:42512
__webpack_require__ @ main-4f877995211a07a39522.js:20
(anonymous) @ main-4f877995211a07a39522.js:66
(anonymous) @ main-4f877995211a07a39522.js:69
main-4f877995211a07a39522.js:42273 Uncaught ReferenceError: YoutubeDL is not defined
    at Main (main-4f877995211a07a39522.js:42273)
    at main-4f877995211a07a39522.js:73768
    at measureLifeCyclePerf (main-4f877995211a07a39522.js:73538)
    at ReactCompositeComponentWrapper._constructComponentWithoutOwner (main-4f877995211a07a39522.js:73767)
    at ReactCompositeComponentWrapper._constructComponent (main-4f877995211a07a39522.js:73742)
    at ReactCompositeComponentWrapper.mountComponent (main-4f877995211a07a39522.js:73650)
    at Object.mountComponent (main-4f877995211a07a39522.js:5328)
    at ReactDOMComponent.mountChildren (main-4f877995211a07a39522.js:78213)
    at ReactDOMComponent._createInitialChildren (main-4f877995211a07a39522.js:75189)
    at ReactDOMComponent.mountComponent (main-4f877995211a07a39522.js:75008)
```

Also, is it intentional that the app 404s at /? Would expect the root to be / and not /liquid-dl/

